### PR TITLE
fix: replacing cat on deploy ui

### DIFF
--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -85,7 +85,9 @@ jobs:
           GROUNDBREAKER_ENVIRONMENT: ${{ inputs.environment }}
         run: |
           yarn pull-env:ci
-          cat .env.${{ inputs.environment }} > .env.production
+        
+      - if: ${{ inputs.environment != 'production' }}
+        run: cat .env.${{ inputs.environment }} > .env.production
 
       - name: Build App
         run: yarn build


### PR DESCRIPTION
## Description

 `cat` was leaving env empty when in production.
Replaced for cp when not in production.

## Is this a breaking change

<!-- Just mark if this breaks anything in the current application. -->

- [ ] Yes
- [X] No
