### PR TITLE
feat: add skip to publish libs to prevent looping

### DIFF
--- a/.github/workflows/publish-monorepo-libs.yml
+++ b/.github/workflows/publish-monorepo-libs.yml
@@ -35,6 +35,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PACKAGEJSON_DIR: ${{ inputs.lib_path }}
+        with:
+          commit-message: 'CI: bumps version to {{version}} [skip ci]'
       - name: Publish
         run: yarn publish
         working-directory: ${{ inputs.lib_path }}


### PR DESCRIPTION
## Description

Because, when bumper merges a commit, the actions can be triggered again.
`[skip ci]` supposedly tricks git actions to not do that again.
