### PR TITLE
deps: update nodeJS runtime version to v16

### DIFF
--- a/.github/workflows/ci-ui.yml
+++ b/.github/workflows/ci-ui.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
           cache: 'yarn'
       - uses: actions/cache@v2
         with:
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
           cache: 'yarn'
       - uses: actions/cache@v2
         with:
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
           cache: 'yarn'
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -70,7 +70,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
           cache: 'yarn'
 
       - uses: actions/cache@v2


### PR DESCRIPTION
## Description

This will make sure the runtime will have all the latest LTS features.

https://github.com/groundbreaker/ui-manager-offerings/runs/6411503628?check_suite_focus=true#:~:text=8614-,TypeError%3A%20html.replaceAll%20is%20not%20a%20function,8615,-8616