### PR TITLE
refactor: remove build since

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -80,12 +80,8 @@ jobs:
             production) echo "::set-output name=short_env::prod" ;;
             *) echo "Invalid environment" && exit 1 ;;
           esac
-      - name: Set build since
-        id: build_since
-        run: echo "::set-output name=build_since::${{ (!inputs.rollback && format('--since origin/{0}~1', github.ref_name)) || '' }}"
     outputs:
       short_env: ${{ steps.short_env.outputs.short_env }}
-      build_since: ${{ steps.build_since.outputs.build_since }}
 
   terraform:
     name: Terraform
@@ -113,7 +109,7 @@ jobs:
           terraform_version: 1.2.1
       - uses: actions/cache@v2
         with:
-          path: '**/node_modules'
+          path: "**/node_modules"
           key: modules-${{ hashFiles('./yarn.lock') }}
       - name: Setup AWS Credentials
         uses: groundbreaker/workflows/.github/actions/setup-aws-credentials@v1
@@ -178,7 +174,7 @@ jobs:
       - name: Cache node_modules
         uses: actions/cache@v2
         with:
-          path: '**/node_modules'
+          path: "**/node_modules"
           key: modules-${{ hashFiles('./yarn.lock') }}
       - name: Setup AWS Credentials
         uses: groundbreaker/workflows/.github/actions/setup-aws-credentials@v1
@@ -193,6 +189,6 @@ jobs:
       - name: Build common packages
         run: lerna run build:common
       - name: Build packages
-        run: lerna run build ${{ needs.temp_vars.outputs.build_since }} --exclude-dependents
+        run: lerna run build --exclude-dependents
       - name: Deploy packages
-        run: lerna run deploy:${{ needs.temp_vars.outputs.short_env }} ${{ needs.temp_vars.outputs.build_since }} --exclude-dependents
+        run: lerna run deploy:${{ needs.temp_vars.outputs.short_env }} --exclude-dependents


### PR DESCRIPTION
This will force the build to be made on all packages on this service (just like we do today on groundbreaker-app).
It will avoid problems like changing a shared package and none of the packages being deployed.